### PR TITLE
Enhancements to ResultWrapper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :gemcutter
+source 'https://rubygems.org'
 
 gemspec
 

--- a/lib/neo4j-cypher/result_wrapper.rb
+++ b/lib/neo4j-cypher/result_wrapper.rb
@@ -13,6 +13,8 @@ module Neo4j
     #   r[0][:n].neo_id.should == @a.neo_id
     #   r[1][:n].neo_id.should == @b.neo_id
     class ResultWrapper
+      class ResultsAlreadyConsumedException < Exception; end;
+
       include Enumerable
 
       # @return the original result from the Neo4j Cypher Engine, once forward read only !
@@ -20,6 +22,7 @@ module Neo4j
 
       def initialize(source)
         @source = source
+        @unread = true
       end
 
       # @return [Array<Symbol>] the columns in the query result
@@ -30,6 +33,9 @@ module Neo4j
       # for the Enumerable contract
       def each
         @source.each { |row| yield map(row) }
+        raise ResultsAlreadyConsumedException unless @unread
+
+          @unread = false
           @source.each { |row| yield symbolize_row_keys(row) }
       end
 

--- a/lib/neo4j-cypher/result_wrapper.rb
+++ b/lib/neo4j-cypher/result_wrapper.rb
@@ -32,11 +32,14 @@ module Neo4j
 
       # for the Enumerable contract
       def each
-        @source.each { |row| yield map(row) }
         raise ResultsAlreadyConsumedException unless @unread
 
+        if block_given?
           @unread = false
           @source.each { |row| yield symbolize_row_keys(row) }
+        else
+          Enumerator.new(self)
+        end
       end
 
       private

--- a/lib/neo4j-cypher/result_wrapper.rb
+++ b/lib/neo4j-cypher/result_wrapper.rb
@@ -30,11 +30,13 @@ module Neo4j
       # for the Enumerable contract
       def each
         @source.each { |row| yield map(row) }
+          @source.each { |row| yield symbolize_row_keys(row) }
       end
 
+      private
+
       # Maps each row so that we can use symbols for column names.
-      # @private
-      def map(row)
+      def symbolize_row_keys(row)
         out = {} # move to a real hash!
         row.each do |key, value|
           out[key.to_sym] = value.respond_to?(:wrapper) ? value.wrapper : value

--- a/spec/result_wrapper_spec.rb
+++ b/spec/result_wrapper_spec.rb
@@ -24,13 +24,15 @@ describe Neo4j::Cypher::ResultWrapper do
     end
 
     it 'symbolize the keys' do
-      subject.first.keys.should =~ [:key1, :key2]
-      subject.to_a[1].keys.should =~ [:key1, :key2]
+      results = subject.to_a
+      results[0].keys.should =~ [:key1, :key2]
+      results[1].keys.should =~ [:key1, :key2]
     end
 
     it 'leaves the values as it is' do
-      subject.first.values.should =~ %w[value1 value2]
-      subject.to_a[1].values.should =~ %w[value3 value4]
+      results = subject.to_a
+      results[0].values.should =~ %w[value1 value2]
+      results[1].values.should =~ %w[value3 value4]
     end
 
   end
@@ -39,7 +41,7 @@ describe Neo4j::Cypher::ResultWrapper do
     let(:wrapper) do
       o = Object.new
       o.stub(:wrapper).and_return('something')
-    end\
+    end
 
     subject do
       Neo4j::Cypher::ResultWrapper.new([{'key1' => wrapper}])
@@ -53,6 +55,21 @@ describe Neo4j::Cypher::ResultWrapper do
       subject.first.values.should == [wrapper]
     end
 
+  end
+
+  context 'results are read-once' do
+    let(:source) { [{a: 10, b: 20}, {a: 100, b: 200}] }
+
+    subject do
+      Neo4j::Cypher::ResultWrapper.new(source)
+    end
+
+    it 'raises an exception upon second pass' do
+      subject.to_a
+      expect do
+        subject.to_a
+      end.to raise_error(Neo4j::Cypher::ResultWrapper::ResultsAlreadyConsumedException)
+    end
   end
 
 end

--- a/spec/result_wrapper_spec.rb
+++ b/spec/result_wrapper_spec.rb
@@ -57,6 +57,29 @@ describe Neo4j::Cypher::ResultWrapper do
 
   end
 
+  context 'each works like a standard ruby Enumerator' do
+    let(:source) { [{a: 10, b: 20}, {a: 100, b: 200}] }
+
+    subject do
+      Neo4j::Cypher::ResultWrapper.new(source)
+    end
+
+    it 'iterates over the source if given a block' do
+      acc = []
+      subject.each {|e| acc << e}
+      acc.should == [{a: 10, b: 20}, {a: 100, b: 200}]
+    end
+
+    it 'return an Enumerator object if not given a block' do
+      subject.each.should be_an(Enumerator)
+    end
+
+    it 'chains enumerable calls' do
+      pairs = subject.each_with_index.map{|row, i| [i, row[:a]] }
+      pairs.should == [[0, 10], [1, 100]]
+    end
+  end
+
   context 'results are read-once' do
     let(:source) { [{a: 10, b: 20}, {a: 100, b: 200}] }
 


### PR DESCRIPTION
After working with the Cypher DSL for a little while I ran into a few things I thought could be improved. Here's my best shot at it.
1. The ResultWrapper is Enumerable, but wasn't chainable. In the Ruby core Enumerables, you can chain the Enumerable calls together. This makes working with them quite nice.

``` ruby
[:a, :b, :c].each_with_index.map{|e, i| "#{i}. #{e}" }
# => ["0. a", "1. b", "2. c"] 
```

I made a small change to make this happen with the ResultWrapper. I think it makes the ResultWrapper a little nicer to work with. This still works as expected with the read-once nature of the ResultWrapper.
1. Which brings up the read-once nature of ResultWrapper...it previously "failed" silently. This was leading me to not trust my explorations in pry. I was constantly rerunning queries while checking to see if the query returned any results. I much prefer to be notified that the results have been emptied than to have it simply return an empty array. 
   The change I've made throws an exception after the first consumption. I had to change a couple of other specs to actually account for this (they didn't actually take into the read-once restriction).
2. I renamed ResultWrapper#map to ResultWrapper#symbolize_row_keys. This means that we don't override #map with a different method signature (letting us directly call #map on our results!). It has a name that fits its real purpose. I also marked it private since it was only annotated before.
3. Most minor of all, this gem hadn't been updated since the Rubygems.org incident, and Bundler was complaining that the Gemfile wasn't using an https source.

I've run all the specs with these changes. I'm quite happy to work with you on any changes (stylistic or otherwise). Keep any commits you like, I'll help fix any that need it, drop any you'd prefer not to have.

I decided to go ahead with these changes in an attempt to make things even a little bit better. Open source FTW.
