### PR TITLE
node updates fail when a property value is set to boolean false

### DIFF
--- a/lib/neo4j-cypher/operator.rb
+++ b/lib/neo4j-cypher/operator.rb
@@ -41,7 +41,7 @@ module Neo4j
         right_operand = Regexp.new(right_operand) if op == '=~' && right_operand.is_a?(String)
         @left_operand = Operand.new(left_operand)
         raise "No Leftoperatnd #{left_operand.class}" unless @left_operand.obj
-        @right_operand = Operand.new(right_operand) if right_operand
+        @right_operand = Operand.new(right_operand) unless right_operand.nil?
         @op = (@right_operand && @right_operand.regexp?) ? '=~' : op
         @post_fix = post_fix
         @valid = true


### PR DESCRIPTION
The cypher query generated without the fix:

START v1=node:idx_node_uuid(uuid="d559cc621ed44f0cbaf238bd6a7cb065") SET =(v1.restricted),v1.uuid = "d559cc621ed44f0cbaf238bd6a7cb065",v1.type = "Organization"

With the fix:

START v1=node:idx_node_uuid(uuid="09bb510d45774d7d96fc057e8eb45c90") SET v1.restricted = false,v1.uuid = "09bb510d45774d7d96fc057e8eb45c90",v1.type = "Organization"

This only happens for boolean property values because of the check if right_operand (which is the value). 

Does not happen on creates, only updates.

Tests pass after this fix.
