### PR TITLE
adding single quotes around lucene query strings

### DIFF
--- a/lib/neo4j-cypher/start.rb
+++ b/lib/neo4j-cypher/start.rb
@@ -59,7 +59,7 @@ module Neo4j
       end
 
       def self.query_node_by_class(clause_list, index_class, query, index_type)
-        LuceneQuery.new(clause_list, "#{_index_name_for_type(index_class, index_type)}(#{query})", 'node')
+        LuceneQuery.new(clause_list, "#{_index_name_for_type(index_class, index_type)}('#{query}')", 'node')
       end
 
       def self.lookup_rel_by_class(clause_list, index_class, key, value)
@@ -67,7 +67,7 @@ module Neo4j
       end
 
       def self.query_rel_by_class(clause_list, index_class, query, index_type)
-        LuceneQuery.new(clause_list, "#{_index_name_for_type(index_class, index_type)}(#{query})", 'relationship')
+        LuceneQuery.new(clause_list, "#{_index_name_for_type(index_class, index_type)}('#{query}')", 'relationship')
       end
 
       def self._index_name_for_type(index_class , index_type)

--- a/spec/cypher_start_spec.rb
+++ b/spec/cypher_start_spec.rb
@@ -213,23 +213,23 @@ describe "Neo4j::Cypher" do
   describe "query" do
 
     describe %q[query('myindex', "name:A")] do
-      it { Proc.new { query('myindex', "name:A") }.should be_cypher(%q[START v1=node:myindex(name:A) RETURN v1]) }
+      it { Proc.new { query('myindex', "name:A") }.should be_cypher(%q[START v1=node:myindex('name:A') RETURN v1]) }
     end
 
 
     describe %q[query_rel('myindex', "name:A")] do
-      it { Proc.new { query_rel('myindex', "name:A") }.should be_cypher(%q[START v1=relationship:myindex(name:A) RETURN v1]) }
+      it { Proc.new { query_rel('myindex', "name:A") }.should be_cypher(%q[START v1=relationship:myindex('name:A') RETURN v1]) }
     end
 
     describe %q[query(FooIndex, "name:A")] do
-      it { Proc.new { query(FooIndex, "name:A") }.should be_cypher(%q[START v1=node:fooindex_exact(name:A) RETURN v1]) }
+      it { Proc.new { query(FooIndex, "name:A") }.should be_cypher(%q[START v1=node:fooindex_exact('name:A') RETURN v1]) }
     end
 
     describe %q[query(FooIndex, "name:A", :fulltext)] do
-      it { Proc.new { query(FooIndex, "name:A", :fulltext) }.should be_cypher(%q[START v1=node:fooindex_fulltext(name:A) RETURN v1]) }
+      it { Proc.new { query(FooIndex, "name:A", :fulltext) }.should be_cypher(%q[START v1=node:fooindex_fulltext('name:A') RETURN v1]) }
     end
   end
-  
+
   describe "lookup" do
 
     describe %q[lookup_rel('myindex', "name", "A")] do


### PR DESCRIPTION
Modifing start.rb and the tests which use it so that lucene query strings are presented within quotes. Using lucene query strings fails in Neo4j 1.94 if they are not within single quotes. 
