### PR TITLE
escape both single and double quotes for string property values

### DIFF
--- a/lib/neo4j-cypher/clause.rb
+++ b/lib/neo4j-cypher/clause.rb
@@ -90,7 +90,7 @@ module Neo4j
       def to_prop_string(props)
         key_values = props.keys.map do |key|
           raw = key.to_s[0, 1] == '_'
-          escaped_string = props[key].gsub(/'/, "\\\\'") if props[key].is_a?(String) && !raw
+          escaped_string = props[key].gsub(/['"]/) { |s| "\#{s}" } if props[key].is_a?(String) && !raw
           val = props[key].is_a?(String) && !raw ? "'#{escaped_string}'" : props[key]
           "#{raw ? key.to_s[1..-1] : key} : #{val}"
         end


### PR DESCRIPTION
was only escaping single quotes before. String values are breaking on double quotes as well, so escaping them as well.

Can you push it to Rubygems when merged? Thanks.
