### PR TITLE
fixed boolean value updates bug

### DIFF
--- a/lib/neo4j-cypher/operator.rb
+++ b/lib/neo4j-cypher/operator.rb
@@ -37,7 +37,9 @@ module Neo4j
 
       def initialize(clause_list, left_operand, right_operand, op, clause_type = :where, post_fix = nil, &dsl)
         super(clause_list, clause_type, EvalContext)
-        right_operand ||= :NULL if op == '='
+        if op == '='
+          right_operand = right_operand.nil? ? :NULL : right_operand
+        end
         right_operand = Regexp.new(right_operand) if op == '=~' && right_operand.is_a?(String)
         @left_operand = Operand.new(left_operand)
         raise "No Leftoperatnd #{left_operand.class}" unless @left_operand.obj


### PR DESCRIPTION
Andreas: this fixes an existing bug on node updates for boolean valued properties. 
The right_operand ||= :NULL sets the value to NULL if right_operand is false (not the expected behavior).

Please review and merge whenever you can. Also, please push to rubygems.
